### PR TITLE
ci: use voidzero-dev/setup-vp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
-      - run: pnpm install
-      - run: pnpm run bench id
-      - run: pnpm run bench transform
+      - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
+        with:
+          cache: true
+      - run: vp run bench id
+      - run: vp run bench transform


### PR DESCRIPTION
Switch CI to [`voidzero-dev/setup-vp`](https://github.com/voidzero-dev/setup-vp) now that the project is on Vite+.

- replace `oxc-project/setup-node` + `pnpm install` with `setup-vp` (`cache: true`, auto-runs `vp install` which also builds the approved `@swc/core`/`esbuild` native deps)
- `pnpm run bench id` / `pnpm run bench transform` → `vp run bench id` / `vp run bench transform`