### PR TITLE
fix(ci): pin vite-plus to 0.1.24 to match vite-plus-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:
+          version: "0.1.24"
           cache: true
       - run: vp run bench id
       - run: vp run bench transform

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,12 @@ settings:
 catalogs:
   default:
     vite-plus:
-      specifier: latest
+      specifier: 0.1.24
       version: 0.1.24
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.24
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.24
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         specifier: 'catalog:'
         version: 0.1.24(@types/node@25.0.2)(esbuild@0.27.7)(typescript@6.0.3)(vite@7.3.1(@types/node@25.0.2)(lightningcss@1.32.0))
       vitest:
-        specifier: npm:@voidzero-dev/vite-plus-test@latest
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@25.0.2)(esbuild@0.27.7)(typescript@6.0.3)(vite@7.3.1(@types/node@25.0.2)(lightningcss@1.32.0))'
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,9 @@ allowBuilds:
   "@swc/core": true
   esbuild: true
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vite-plus: latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.24
+  vite-plus: 0.1.24
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.24
 overrides:
   vite: "catalog:"
   vitest: "catalog:"


### PR DESCRIPTION
## Problem

Benchmark CI fails (e.g. [run on #234](https://github.com/oxc-project/bench-transformer/actions/runs/27845075422/job/82412408647?pr=234)) with:

```
Could not find 'vitest' bin entry in node_modules/.pnpm/@voidzero-dev+vite-plus-test@0.1.24/.../package.json
```

## Cause

The `pnpm-workspace.yaml` catalog pinned everything to `latest`:

- `vite-plus: latest` → resolves to **0.2.1** (depends on `@voidzero-dev/vite-plus-core@0.2.1`)
- `vitest: @voidzero-dev/vite-plus-test@latest` → still **0.1.24** (depends on `@voidzero-dev/vite-plus-core@0.1.24`)

`vite-plus` 0.2.x has been published ahead of a matching `vite-plus-test`, so the toolchain ends up with mismatched `vite-plus-core` versions and `vp test` can no longer resolve the vitest bin.

## Fix

Pin the catalog trio and the `setup-vp` action to the coherent **0.1.24** release. Verified locally — `vp run bench id` and `vp run bench transform` both pass again.